### PR TITLE
Add support to Paper PluginBootstrap

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,8 +18,8 @@ val kotlinIoVersion = version("kotlinx-io")
 val dateTimeVersion = version("kotlinx-datetime")
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 group = "me.gamercoder215.kotlinmc"
@@ -92,7 +92,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:${kotlinIoVersion}")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:${dateTimeVersion}")
 
-    compileOnly("org.spigotmc:spigot-api:1.8-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
     compileOnly("net.md-5:bungeecord-api:1.8-SNAPSHOT")
     compileOnly("com.velocitypowered:velocity-api:3.1.1")
     compileOnly("org.spongepowered:spongeapi:8.0.0")

--- a/src/main/java/xyz/gmitch215/kotlinmc/Paper.java
+++ b/src/main/java/xyz/gmitch215/kotlinmc/Paper.java
@@ -1,0 +1,6 @@
+package xyz.gmitch215.kotlinmc;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class Paper extends JavaPlugin {
+}

--- a/src/main/java/xyz/gmitch215/kotlinmc/PaperPluginBootstrap.java
+++ b/src/main/java/xyz/gmitch215/kotlinmc/PaperPluginBootstrap.java
@@ -1,0 +1,11 @@
+package xyz.gmitch215.kotlinmc;
+
+import io.papermc.paper.plugin.bootstrap.BootstrapContext;
+import io.papermc.paper.plugin.bootstrap.PluginBootstrap;
+import org.jetbrains.annotations.NotNull;
+
+public class PaperPluginBootstrap implements PluginBootstrap {
+    @Override public void bootstrap(@NotNull final BootstrapContext context) {
+    }
+}
+

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,0 +1,9 @@
+name: Kotlin
+main: xyz.gmitch215.kotlinmc.Paper
+bootstrapper: xyz.gmitch215.kotlinmc.PaperPluginBootstrap
+version: ${project.ext.kotlin_version}
+description: ${project.description}
+api-version: 1.21
+author: gmitch215
+folia-supported: true
+website: ${project.ext.url}


### PR DESCRIPTION
## Info
This PR closes #1

## Details
Add support to Paper PluginBootstrap. This allows to run Kotlin code in PluginBootstrap.

## Tested Environments
Paper 1.21.1

### OS
OS: Win / Mac / Linux / xxxx

## Demonstration
None